### PR TITLE
Make zookeeper multi-arch, add ppc64le

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,6 +1,8 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 
+Architectures: amd64, ppc64le
+
 Tags: 3.3.6, 3.3
 GitCommit: 9f00dd78dcd67baa9b57449329fcbd4744948326
 Directory: 3.3.6


### PR DESCRIPTION
Since the alpine image is now multi-arch, zookeeper can also be multi-arch

Verified zookeeper dockerfiles for ppc64le hence proposing this change